### PR TITLE
Implement IAsyncEnumerable on CosmosLinqQuery

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -285,6 +285,32 @@ namespace Microsoft.Azure.Cosmos.Linq
         }
 
         /// <summary>
+        /// This extension method returns the query as an asynchronous enumerable.
+        /// </summary>
+        /// <typeparam name="T">the type of object to query.</typeparam>
+        /// <param name="query">the IQueryable{T} to be converted.</param>
+        /// <returns>An asynchronous enumerable to go through the items.</returns>
+        /// <example>
+        /// This example shows how to get the query as an asynchronous enumerable.
+        /// 
+        /// <code language="c#">
+        /// <![CDATA[
+        /// IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>();
+        /// IAsyncEnumerable<ToDoActivity> asyncEnumerable = linqQueryable.Where(item => (item.taskNum < 100)).AsAsyncEnumerable();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> query)
+        {
+            if (query is IAsyncEnumerable<T> asyncEnumerable)
+            {
+                return asyncEnumerable;
+            }
+
+            throw new ArgumentException("AsAsyncEnumerable is only supported on Cosmos LINQ query operations", nameof(query));
+        }
+
+        /// <summary>
         /// This extension method gets the FeedIterator from LINQ IQueryable to execute query asynchronously.
         /// This will create the fresh new FeedIterator when called.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -142,6 +142,31 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task LinqQueryToAsyncEnumerable()
+        {
+            ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
+            toDoActivity.taskNum = 20;
+            toDoActivity.id = "minTaskNum";
+            await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.pk));
+            toDoActivity.taskNum = 100;
+            toDoActivity.id = "maxTaskNum";
+            await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.pk));
+
+            IAsyncEnumerable<ToDoActivity> query = this.Container.GetItemLinqQueryable<ToDoActivity>()
+                .OrderBy(p => p.cost)
+                .AsAsyncEnumerable();
+
+            int found = 0;
+            await foreach (ToDoActivity item in query)
+            {
+                Assert.IsNotNull(item);
+                ++found;
+            }
+
+            Assert.IsTrue(found > 0);
+        }
+
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         [ExpectedException(typeof(NotSupportedException))]


### PR DESCRIPTION
# Pull Request Template

## Description

This updates CosmosLinqQuery to support IAsyncEnumerable, a new 'AsAsyncEnumerable' extension method, and a test method to utilize the new extension method

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

#903